### PR TITLE
remove prefix "chr" from "chrom" property for reads in bam file

### DIFF
--- a/parsebam/hashtable.c
+++ b/parsebam/hashtable.c
@@ -33,6 +33,11 @@ int insert_keyvalue(HASHTABLE* ht, char* key,int slen,int value)
 
 int getindex(HASHTABLE* ht,char* chrom)
 {
+        if (strlen(chrom) > 3) {  //"chr\d+"
+	  fprintf(stderr, "rename chromosome from : %s to %s\n", chrom, &chrom[3]);
+	  chrom = &chrom[3];
+	}
+
         int hash = hashstring(chrom,ht->htsize); keypointer = ht->blist[hash];
 	while (keypointer != NULL)
 	{


### PR DESCRIPTION
Sometimes bam files were aligned to assembly with chromsome names including string "chr", e.g. "chr1", "chr2", etc. This create mismatch with default chromosomes in current program, expecting 1, 2, etc.